### PR TITLE
:bug: Fix cursor position in tables

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,16 +1,18 @@
 module.exports = {
   NAME_SPACE: '__quilicicf',
+  DEPTH: 'depth',
   CONTAINS_CURSOR: 'containsCursor',
   IS_CURSOR_AT_END: 'isCursorAtEnd',
-  IS_CURSOR_JUST_AFTER_END: 'isCursorJustAfterEnd',
+  IS_CURSOR_JUST_BEFORE_START: 'isCursorJustBeforeStart',
   CURSOR_RELATIVE_OFFSET: 'cursorRelativeOffset',
   STRINGIFY_OPTIONS: {
-    gfm: true,
     bullet: '*',
+    emphasis: '_',
+    fences: true,
+    gfm: true,
     listItemIndent: '1',
     rule: '-',
     ruleSpaces: false,
     strong: '_',
-    emphasis: '_',
   },
 };

--- a/lib/remark-plugins/annotate/index.js
+++ b/lib/remark-plugins/annotate/index.js
@@ -45,9 +45,16 @@ const recursiveAnnotateNodes = (nodes, cursorPosition, depth = 1) => {
 
     recursiveAnnotateNodes(node.children, cursorPosition, depth + 1);
   });
+
+  if (depth === 1 && !STATE.hasFoundCursor) {
+    const lastNode = _.last(nodes);
+    _.set(lastNode, [ NAME_SPACE, CONTAINS_CURSOR ], true);
+    _.set(lastNode, [ NAME_SPACE, IS_CURSOR_AT_END ], true);
+  }
 };
 
 module.exports = (options) => {
   const { cursorPosition } = options;
-  return cursorPosition ? tree => recursiveAnnotateNodes(tree.children, cursorPosition) : _.noop;
+  if (_.isUndefined(cursorPosition)) { return _.noop; }
+  return tree => recursiveAnnotateNodes(tree.children, cursorPosition);
 };

--- a/lib/remark-plugins/annotate/index.js
+++ b/lib/remark-plugins/annotate/index.js
@@ -5,30 +5,49 @@ const computeRelativeOffset = require('./computeRelativeOffset');
 const isInRange = require('../../isInRange');
 const {
   NAME_SPACE,
+  DEPTH,
   CONTAINS_CURSOR,
   IS_CURSOR_AT_END,
-  IS_CURSOR_JUST_AFTER_END,
+  IS_CURSOR_JUST_BEFORE_START,
   CURSOR_RELATIVE_OFFSET,
 } = require('../../constants');
 
-const annotateNodes = (nodes, cursorPosition) => {
+const recursiveAnnotateNodes = (nodes, cursorPosition, depth = 1) => {
+  const STATE = {
+    hasFoundCursor: false,
+  };
   _.each(nodes, (node) => {
+    _.set(node, [ NAME_SPACE, DEPTH ], depth);
+
     const startPosition = node.position.start.offset;
-    const endPosition = node.position.end.offset;
-    const isCursorInsideNode = isInRange(cursorPosition, { min: startPosition, max: endPosition });
-    const isCursorAtEnd = cursorPosition === endPosition;
-    const isCursorJustAfterEnd = cursorPosition === endPosition + 1;
 
-    _.set(node, [ NAME_SPACE, CONTAINS_CURSOR ], isCursorInsideNode);
-    _.set(node, [ NAME_SPACE, IS_CURSOR_AT_END ], isCursorAtEnd);
-    _.set(node, [ NAME_SPACE, IS_CURSOR_JUST_AFTER_END ], isCursorJustAfterEnd);
+    if (startPosition > cursorPosition
+      && depth === 1
+      && !STATE.hasFoundCursor) {
+      STATE.hasFoundCursor = true;
+      _.set(node, [ NAME_SPACE, CONTAINS_CURSOR ], true);
+      _.set(node, [ NAME_SPACE, IS_CURSOR_JUST_BEFORE_START ], true);
 
-    const relativeOffset = computeRelativeOffset(isCursorInsideNode, startPosition, endPosition, cursorPosition);
-    _.set(node, [ NAME_SPACE, CURSOR_RELATIVE_OFFSET ], relativeOffset);
+    } else {
+      const endPosition = node.position.end.offset;
+      const isCursorInsideNode = isInRange(cursorPosition, { min: startPosition, max: endPosition });
+      const isCursorAtEnd = cursorPosition === endPosition;
+
+      STATE.hasFoundCursor = STATE.hasFoundCursor || isCursorInsideNode;
+      _.set(node, [ NAME_SPACE, CONTAINS_CURSOR ], isCursorInsideNode);
+      _.set(node, [ NAME_SPACE, IS_CURSOR_AT_END ], isCursorAtEnd);
+
+      if (isCursorInsideNode) {
+        const relativeOffset = computeRelativeOffset(isCursorInsideNode, startPosition, endPosition, cursorPosition);
+        _.set(node, [ NAME_SPACE, CURSOR_RELATIVE_OFFSET ], relativeOffset);
+      }
+    }
+
+    recursiveAnnotateNodes(node.children, cursorPosition, depth + 1);
   });
 };
 
 module.exports = (options) => {
   const { cursorPosition } = options;
-  return cursorPosition ? tree => annotateNodes(tree.children, cursorPosition) : _.noop;
+  return cursorPosition ? tree => recursiveAnnotateNodes(tree.children, cursorPosition) : _.noop;
 };

--- a/lib/remark-plugins/cursor/createVisitorWithoutArgMessage.js
+++ b/lib/remark-plugins/cursor/createVisitorWithoutArgMessage.js
@@ -1,0 +1,4 @@
+module.exports = visitorName => (
+  `Found a level 1 markdown node whose visitor of type ${visitorName} has no argument.
+This can mess with the cursor position in the formatted file.`
+);

--- a/lib/remark-plugins/cursor/index.js
+++ b/lib/remark-plugins/cursor/index.js
@@ -1,28 +1,8 @@
 const _ = require('lodash');
 
-const {
-  NAME_SPACE,
-  CONTAINS_CURSOR,
-  IS_CURSOR_AT_END,
-  IS_CURSOR_JUST_AFTER_END,
-  CURSOR_RELATIVE_OFFSET,
-} = require('../../constants');
-
-const createVisitorWithoutArgMessage = visitorName => (
-  `Found a level 1 markdown node whose visitor of type ${visitorName} has no argument.
-This can mess with the cursor position in the formatted file.`
-);
-
-const setPositionFromState = (options, state) => {
-  // eslint-disable-next-line no-param-reassign
-  options.newCursorPosition = {
-    line: state.newCursorLine,
-    column: state.newCursorColumn,
-  };
-};
+const updateCursorPosition = require('./updateCursorPosition');
 
 module.exports = function constructor (options) {
-  const { cursorPosition } = options;
   const { Compiler } = this;
   const { visitors } = Compiler.prototype;
 
@@ -32,74 +12,12 @@ module.exports = function constructor (options) {
     hasFoundNewCursorPosition: false, // Set once
   };
 
-  const updateCursorPosition = (originalVisitor, file) => {
-    if (originalVisitor.name === 'root') {
-      return originalVisitor;
-    }
-
-    function cursorPositionUpdater (...args) {
-      const [ node ] = args;
-      const stringifiedNode = originalVisitor.apply(this, args);
-
-      const isTooDeepToBeConsidered = node && !_.has(node, [ NAME_SPACE ]); // Only level-1 nodes handled
-      if (STATE.hasFoundNewCursorPosition || isTooDeepToBeConsidered) {
-        return stringifiedNode;
-      }
-
-      if (_.isEmpty(args)) {
-        // eslint-disable-next-line no-param-reassign
-        // offset += _.size(stringifiedNode);
-        file.message(createVisitorWithoutArgMessage(originalVisitor.name));
-        return stringifiedNode;
-      }
-
-      const stringifiedNodeSize = _.size(stringifiedNode);
-      const stringifiedNodeLinesNumber = _.size(stringifiedNode.split('\n')) + 1; // Trailing line break
-
-      if (!_.has(node, [ NAME_SPACE ])) { // Not a level 1 node
-        return stringifiedNode;
-      }
-
-      const isCursorAtEnd = _.get(node, [ NAME_SPACE, IS_CURSOR_AT_END ]);
-      if (isCursorAtEnd) {
-        STATE.newCursorColumn = stringifiedNodeSize;
-        STATE.hasFoundNewCursorPosition = true;
-        setPositionFromState(options, STATE);
-        return stringifiedNode;
-      }
-
-      const isCursorJustAfterEnd = _.get(node, [ NAME_SPACE, IS_CURSOR_JUST_AFTER_END ]);
-      if (isCursorJustAfterEnd) {
-        STATE.newCursorColumn = stringifiedNodeSize + 1; // Just after => +1
-        STATE.hasFoundNewCursorPosition = true;
-        setPositionFromState(options, STATE);
-        return stringifiedNode;
-      }
-
-      const containsCursor = _.get(node, [ NAME_SPACE, CONTAINS_CURSOR ]);
-      if (containsCursor) {
-        // Best guess, let's hope formatting did not change the size of the block
-        STATE.newCursorColumn = _.get(node, [ NAME_SPACE, CURSOR_RELATIVE_OFFSET ]);
-        STATE.hasFoundNewCursorPosition = true;
-        setPositionFromState(options, STATE);
-        return stringifiedNode;
-      }
-
-      STATE.newCursorLine += stringifiedNodeLinesNumber;
-      return stringifiedNode;
-    }
-
-    const newFunction = cursorPositionUpdater;
-    newFunction.name = originalVisitor.name;
-    newFunction.length = originalVisitor.length;
-    return newFunction;
-  };
-
   function transformer (tree, file) {
-    if (cursorPosition) {
-      Compiler.prototype.visitors = _.mapValues(
-        visitors,
-        visitor => updateCursorPosition(visitor, file),
+    if (options.cursorPosition) {
+      _.set( // WARNING: must update parameters to change Compiler behavior
+        Compiler,
+        [ 'prototype', 'visitors' ],
+        _.mapValues(visitors, visitor => updateCursorPosition(visitor, file, options, STATE)),
       );
     }
   }

--- a/lib/remark-plugins/cursor/setPositionFromState.js
+++ b/lib/remark-plugins/cursor/setPositionFromState.js
@@ -1,0 +1,10 @@
+/**
+ * Must mutate input to make cursor information go up the chain.
+ */
+module.exports = (options, state) => {
+  // eslint-disable-next-line no-param-reassign
+  options.newCursorPosition = {
+    line: state.newCursorLine,
+    column: state.newCursorColumn,
+  };
+};

--- a/lib/remark-plugins/cursor/updateCursorPosition.js
+++ b/lib/remark-plugins/cursor/updateCursorPosition.js
@@ -1,0 +1,119 @@
+const _ = require('lodash');
+
+const updateState = require('./updateState');
+const setPositionFromState = require('./setPositionFromState');
+const createVisitorWithoutArgMessage = require('./createVisitorWithoutArgMessage');
+const {
+  NAME_SPACE,
+  DEPTH,
+  CONTAINS_CURSOR,
+  IS_CURSOR_AT_END,
+  IS_CURSOR_JUST_BEFORE_START,
+  CURSOR_RELATIVE_OFFSET,
+} = require('../../constants');
+
+/**
+ * Special case because the padding option adds characters to the line
+ * which complicates positioning of the cursor.
+ */
+const handleTable = (tableNode, stringifiedNode, options, STATE) => {
+  const insidePosition = _.reduce(
+    tableNode.children,
+    (seed, tableRowNode) => {
+      if (seed.hasMatched) { return seed; }
+
+      const annotation = tableRowNode[ NAME_SPACE ];
+      if (!annotation[ CONTAINS_CURSOR ]) {
+        return { line: seed.line + 1, column: -1, hasMatched: false };
+      }
+
+      if (annotation[ IS_CURSOR_AT_END ]) {
+        // TODO: compute real end of line
+        return { line: seed.line, column: annotation[ CURSOR_RELATIVE_OFFSET ], hasMatched: true };
+      }
+
+      if (annotation[ IS_CURSOR_JUST_BEFORE_START ]) {
+        return { line: seed.line - 1, column: 0, hasMatched: true };
+      }
+
+      return { line: seed.line, column: annotation[ CURSOR_RELATIVE_OFFSET ], hasMatched: true };
+    },
+    { line: 1, column: -1, hasMatched: false },
+  );
+
+  updateState(STATE, {
+    newCursorLine: STATE.newCursorLine + insidePosition.line,
+    newCursorColumn: insidePosition.column,
+    hasFoundNewCursorPosition: true,
+  });
+  setPositionFromState(options, STATE);
+  return stringifiedNode;
+};
+
+module.exports = (originalVisitor, file, options, STATE) => {
+  if (originalVisitor.name === 'root') {
+    return originalVisitor;
+  }
+
+  function cursorPositionUpdater (...args) {
+    const [ node ] = args;
+    const stringifiedNode = originalVisitor.apply(this, args);
+
+    const isTooDeepToBeConsidered = _.get(node, [ NAME_SPACE, DEPTH ]) > 1;
+    if (STATE.hasFoundNewCursorPosition || isTooDeepToBeConsidered) { return stringifiedNode; }
+
+    if (_.isEmpty(args)) {
+      file.message(createVisitorWithoutArgMessage(originalVisitor.name));
+      return stringifiedNode;
+    }
+
+    const annotation = node[ NAME_SPACE ] || {};
+    const stringifiedNodeLines = stringifiedNode.split('\n');
+    const stringifiedNodeLastLine = _.last(stringifiedNodeLines);
+    const stringifiedNodeLinesNumber = _.size(stringifiedNodeLines);
+
+    if (!annotation[ CONTAINS_CURSOR ]) {
+      updateState(STATE, {
+        newCursorLine: STATE.newCursorLine + stringifiedNodeLinesNumber + 1, // Tailing \n
+      });
+      return stringifiedNode;
+    }
+
+    if (originalVisitor.name === 'table') { // Tables are an especially tricky case
+      return handleTable(node, stringifiedNode, options, STATE);
+    }
+
+    if (annotation[ IS_CURSOR_AT_END ]) {
+      updateState(STATE, {
+        newCursorLine: STATE.newCursorLine + stringifiedNodeLinesNumber - 1,
+        newCursorColumn: _.size(stringifiedNodeLastLine),
+        hasFoundNewCursorPosition: true,
+      });
+      setPositionFromState(options, STATE);
+      return stringifiedNode;
+    }
+
+    if (annotation[ IS_CURSOR_JUST_BEFORE_START ]) {
+      updateState(STATE, {
+        newCursorLine: STATE.newCursorLine - 1,
+        newCursorColumn: 0,
+        hasFoundNewCursorPosition: true,
+      });
+      setPositionFromState(options, STATE);
+      return stringifiedNode;
+    }
+
+    updateState(STATE, {
+      newCursorLine: STATE.newCursorLine + stringifiedNodeLinesNumber - 1,
+      newCursorColumn: annotation[ CURSOR_RELATIVE_OFFSET ],
+      hasFoundNewCursorPosition: true,
+    });
+    setPositionFromState(options, STATE);
+    return stringifiedNode;
+  }
+
+  const newFunction = cursorPositionUpdater;
+  newFunction.name = originalVisitor.name;
+  newFunction.length = originalVisitor.length;
+  return newFunction;
+};

--- a/lib/remark-plugins/cursor/updateState.js
+++ b/lib/remark-plugins/cursor/updateState.js
@@ -1,0 +1,13 @@
+const _ = require('lodash');
+
+/* eslint-disable no-param-reassign */
+module.exports = (STATE, {
+  newCursorLine = undefined,
+  newCursorColumn = undefined,
+  hasFoundNewCursorPosition = undefined,
+}) => {
+
+  if (!_.isUndefined(newCursorLine)) { STATE.newCursorLine = newCursorLine; }
+  if (!_.isUndefined(newCursorColumn)) { STATE.newCursorColumn = newCursorColumn; }
+  if (!_.isUndefined(hasFoundNewCursorPosition)) { STATE.hasFoundNewCursorPosition = hasFoundNewCursorPosition; }
+};

--- a/lib/remark-plugins/toc/index.js
+++ b/lib/remark-plugins/toc/index.js
@@ -3,11 +3,17 @@ const buildNode = require('unist-builder');
 const makeToc = require('mdast-util-toc');
 
 const findTocStart = require('./findTocStart');
+const recursiveSetDepth = require('./recursiveSetDepth');
 const parseTocConfiguration = require('./parseTocConfiguration');
 const getWasCursorPositionInToc = require('./getWasCursorPositionInToc');
 
 const isInRange = require('../../isInRange');
-const { NAME_SPACE, CONTAINS_CURSOR, IS_CURSOR_AT_END } = require('../../constants');
+const {
+  NAME_SPACE,
+  DEPTH,
+  CONTAINS_CURSOR,
+  IS_CURSOR_AT_END,
+} = require('../../constants');
 
 const DEFAULT_CONFIGURATION = { min: 2, max: 4 };
 
@@ -29,15 +35,15 @@ const transformer = (tree, file) => {
     part => part.type === 'heading' && isInRange(part.depth, tocConfiguration),
   );
 
-  const toc = makeToc(buildNode('root', filteredHeadings));
+  const toc = makeToc(buildNode('root', filteredHeadings)).map;
 
   const wasCursorPositionInToc = getWasCursorPositionInToc(tocStartFinder.tocContent);
-  _.each(
-    [ CONTAINS_CURSOR, IS_CURSOR_AT_END ],
-    attribute => _.set(toc, [ 'map', NAME_SPACE, attribute ], wasCursorPositionInToc),
-  );
+  _.set(toc, [ NAME_SPACE, CONTAINS_CURSOR ], wasCursorPositionInToc);
+  _.set(toc, [ NAME_SPACE, IS_CURSOR_AT_END ], wasCursorPositionInToc);
+  _.set(toc, [ NAME_SPACE, DEPTH ], 1);
+  recursiveSetDepth(toc.children);
 
-  tree.children.splice(tocStartFinder.tocStartIndex + 1, tocStartFinder.tocSize, toc.map);
+  tree.children.splice(tocStartFinder.tocStartIndex + 1, tocStartFinder.tocSize, toc);
 };
 
 module.exports = () => transformer;

--- a/lib/remark-plugins/toc/recursiveSetDepth.js
+++ b/lib/remark-plugins/toc/recursiveSetDepth.js
@@ -1,0 +1,14 @@
+const _ = require('lodash');
+
+const { NAME_SPACE, DEPTH } = require('../../constants');
+
+const recursiveSetDepth = (nodes, depth = 2) => {
+  if (nodes && !_.isEmpty(nodes)) {
+    _.each(nodes, (node) => {
+      _.set(node, [ NAME_SPACE, DEPTH ], depth);
+      recursiveSetDepth(node.children, depth + 1);
+    });
+  }
+};
+
+module.exports = recursiveSetDepth;

--- a/lib/stringifyOptions.js
+++ b/lib/stringifyOptions.js
@@ -1,9 +1,0 @@
-module.exports = {
-  gfm: true,
-  bullet: '*',
-  listItemIndent: '1',
-  rule: '-',
-  ruleSpaces: false,
-  strong: '_',
-  emphasis: '_',
-};

--- a/test/data/simple/input.md
+++ b/test/data/simple/input.md
@@ -27,6 +27,10 @@ Come on Amy, I'm a normal bloke, tell me what normal blokes do! You know when gr
 Haha tricky innit?
 ```
 
+```
+This code should still be in fences after formatting
+```
+
 ~~~js
 process.stderr.write('Wrong fences bro!');
 ~~~
@@ -50,3 +54,9 @@ process.stderr.write('Wrong fences bro!');
 1. Saving the world with meals on wheels.
     1. The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant.
 1. I hate yogurt. It's just stuff with bits in.
+
+A paragraph
+
+
+
+A paragraph very far apart from the previous one

--- a/test/data/simple/output.md
+++ b/test/data/simple/output.md
@@ -31,6 +31,10 @@ Come on Amy, I'm a normal bloke, tell me what normal blokes do! You know when gr
 Haha tricky innit?
 ```
 
+```
+This code should still be in fences after formatting
+```
+
 ```js
 process.stderr.write('Wrong fences bro!');
 ```
@@ -54,3 +58,7 @@ process.stderr.write('Wrong fences bro!');
 1. Saving the world with meals on wheels.
    1. The way I see it, every life is a pile of good things and bad things.…hey.…the good things don't always soften the bad things; but vice-versa the bad things don't necessarily spoil the good things and make them unimportant.
 2. I hate yogurt. It's just stuff with bits in.
+
+A paragraph
+
+A paragraph very far apart from the previous one

--- a/test/data/table/input.md
+++ b/test/data/table/input.md
@@ -1,0 +1,8 @@
+## With a table
+
+| The|Table|Awesome|
+|:--|:---:|--:|
+|Titi| titititititi|titi|
+|Tata| tatatatatata|tata|
+|Toto| totototototo|toto|
+|Tutu| tutu|tutu|

--- a/test/data/table/output.md
+++ b/test/data/table/output.md
@@ -1,0 +1,8 @@
+## With a table
+
+| The  |     Table    | Awesome |
+| :--- | :----------: | ------: |
+| Titi | titititititi |    titi |
+| Tata | tatatatatata |    tata |
+| Toto | totototototo |    toto |
+| Tutu |     tutu     |    tutu |

--- a/test/makeComparableFormattingResult.js
+++ b/test/makeComparableFormattingResult.js
@@ -1,0 +1,8 @@
+module.exports = (newCursorOffset, newCursorPosition, fileContent) => `---
+Offset: ${newCursorOffset}
+Position:
+  line: ${newCursorPosition.line}
+  column: ${newCursorPosition.column}
+Content: 
+${fileContent.substring(0, newCursorOffset)}
+`;

--- a/test/testCursorPosition.spec.js
+++ b/test/testCursorPosition.spec.js
@@ -1,21 +1,30 @@
 const _ = require('lodash');
 
 const loadDataSets = require('./loadDataSets');
+const makeComparableFormattingResult = require('./makeComparableFormattingResult');
 const formatFromString = require('../lib/formatFromString');
 
-const TESTS_DATA_SETS = [
-  [ 'at document start', 'document start', 0, 0 ],
-  [ 'inside the ToC marker', 'same place in ToC marker', 54, 54 ],
-  [ 'inside the ToC', 'end of the ToC', 80, 243 ],
-  [ 'inside a paragraph', 'same place in paragraph', 170, 315 ],
-  [ 'at the end of a paragraph', 'end of paragraph', 174, 319 ],
-  [ 'between paragraphs', 'between the same paragraphs', 14, 14 ],
+const SIMPLE_DATA_SETS = [
+  [ 'at document start', 'document start', 0, 0, { line: 0, column: 0 } ],
+  [ 'inside the ToC marker', 'same place in ToC marker', 54, 54, { line: 5, column: 24 } ],
+  [ 'inside the ToC', 'end of the ToC', 80, 243, { line: 12, column: 49 } ],
+  [ 'inside a paragraph', 'same place in paragraph', 170, 315, { line: 18, column: 32 } ],
+  [ 'at the end of a paragraph', 'end of paragraph', 174, 319, { line: 18, column: 36 } ],
+  [ 'between paragraphs', 'between the same paragraphs', 14, 14, { line: 2, column: 0 } ],
+  [ 'between far-away paragraphs', 'between the same paragraphs', 1537, 2035, { line: 63, column: 0 } ],
+];
+
+const TABLE_DATA_SETS = [
+  [ 'in a table row that will be padded', 'in the same row, column is meh', 129, 176, { line: 7, column: 23 } ],
+  [ 'at the end of a table row', 'in the same row, column is meh', 131, 178, { line: 7, column: 25 } ],
 ];
 
 const FILE_CONTENTS = {
   SIMPLE: {
-    INPUT_PATH: '',
-    OUTPUT_PATH: '',
+    INPUT: '',
+    OUTPUT: '',
+  },
+  TABLE: {
     INPUT: '',
     OUTPUT: '',
   },
@@ -25,18 +34,37 @@ describe('Re-locate cursor position', () => {
 
   beforeAll(() => _.assign(FILE_CONTENTS, loadDataSets(FILE_CONTENTS)));
 
-  test.each(TESTS_DATA_SETS)(
-    'It should relocate the cursor position from %s to %s',
-    async (inputLabel, outputLabel, inputOffset, outputOffset) => {
+  test.each(SIMPLE_DATA_SETS)(
+    'It should relocate the cursor position from %s to %s in the simple data set',
+    async (inputLabel, outputLabel, inputOffset, outputOffset, outputPosition) => {
       const {
         contents: fileContent,
         newCursorOffset,
+        newCursorPosition,
       } = await formatFromString(FILE_CONTENTS.SIMPLE.INPUT, inputOffset);
 
-      expect(fileContent.substring(0, newCursorOffset))
-        .toBe(FILE_CONTENTS.SIMPLE.OUTPUT.substring(0, outputOffset));
+      const expected = makeComparableFormattingResult(outputOffset, outputPosition, FILE_CONTENTS.SIMPLE.OUTPUT);
 
-      expect(newCursorOffset).toBe(outputOffset);
+      expect(makeComparableFormattingResult(newCursorOffset, newCursorPosition, fileContent)).toBe(expected);
+
+      process.stdout.write(`${expected}\n`);
+    },
+  );
+
+  test.each(TABLE_DATA_SETS)(
+    'It should relocate the cursor position from %s to %s in the table data set',
+    async (inputLabel, outputLabel, inputOffset, outputOffset, outputPosition) => {
+      const {
+        contents: fileContent,
+        newCursorOffset,
+        newCursorPosition,
+      } = await formatFromString(FILE_CONTENTS.TABLE.INPUT, inputOffset);
+
+      const expected = makeComparableFormattingResult(outputOffset, outputPosition, FILE_CONTENTS.TABLE.OUTPUT);
+
+      expect(makeComparableFormattingResult(newCursorOffset, newCursorPosition, fileContent)).toBe(expected);
+
+      process.stdout.write(`${expected}\n`);
     },
   );
 });

--- a/test/testCursorPosition.spec.js
+++ b/test/testCursorPosition.spec.js
@@ -12,6 +12,8 @@ const SIMPLE_DATA_SETS = [
   [ 'at the end of a paragraph', 'end of paragraph', 174, 319, { line: 18, column: 36 } ],
   [ 'between paragraphs', 'between the same paragraphs', 14, 14, { line: 2, column: 0 } ],
   [ 'between far-away paragraphs', 'between the same paragraphs', 1537, 2035, { line: 63, column: 0 } ],
+  [ 'just before end', 'just before end', 1587, 2084, { line: 64, column: 48 } ],
+  [ 'at document end', 'document end', 1588, 2084, { line: 64, column: 48 } ],
 ];
 
 const TABLE_DATA_SETS = [


### PR DESCRIPTION
## What is this PR solving 

The stringify options specify that the tables are padded. Given that a table is a single node spanning multiple lines and that it could be heavily padded, the naive implementation in place to re-locate the cursor was far from sufficient to handle tables. 

Also, when there were multiple line breaks between nodes, the annotation plugin was not able to spot where the cursor was which screwed the cursor position too.

## Solution taken to fix the issues

The annotation plugin now annotates deeply, and can find the leaf where the cursor was. This means that we are now able to isolate the complexity of cursor positioning in a single table row. Still not ideal but way better (before, the cursor could go up or down multiple lines). 

For the multiple line breaks, the annotation plugin now has a state and can spot that we are inspecting a node AFTER the cursor without having found which node it's supposed to be in.

## Bonus

The stringify plugin was not configured to force fences on code blocks without specified language. It now does.